### PR TITLE
Fix lerna version for assertion sync

### DIFF
--- a/.github/workflows/assertionscsv-update.yml
+++ b/.github/workflows/assertionscsv-update.yml
@@ -17,6 +17,8 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: "16"
+            - name: Use lerna
+              run: npm install -g lerna@6.6.2
             - name: Install dependencies
               run: lerna bootstrap --no-ci
             - name: Fetch updated assertions.csv


### PR DESCRIPTION
So that we avoid the failure at https://github.com/eclipse-thingweb/playground/actions/runs/5675270167/workflow