### PR TITLE
ci: fix lerna version for assertions

### DIFF
--- a/.github/workflows/assertionscsv-update.yml
+++ b/.github/workflows/assertionscsv-update.yml
@@ -17,6 +17,8 @@ jobs:
             - uses: actions/setup-node@v2
               with:
                   node-version: "16"
+            - name: Use lerna
+              run: npm install -g lerna@6.6.2
             - name: Install dependencies
               run: lerna bootstrap --no-ci
             - name: Fetch updated assertions.csv


### PR DESCRIPTION
In order to avoid cases such as https://github.com/eclipse-thingweb/playground/actions/runs/5745360467/workflow