### PR TITLE
Ignore old web package from testing and fix node versions

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -19,7 +19,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [16.x, 18.x]
+                node-version: [18.x, 20.x]
 
         steps:
             - name: Checkout

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -37,7 +37,7 @@ jobs:
               run: lerna bootstrap --no-ci
 
             - name: Test
-              run: lerna run test --no-bail --stream
+              run: lerna run test --no-bail --stream --ignore=packages/web
 
             - name: TD test
               run: node packages/cli/index.js -i examples/td/*/*.jsonld


### PR DESCRIPTION
It is going to be phased out. 