### PR TITLE
Lighthouse scores based on Desktop

### DIFF
--- a/packages/web/netlify.toml
+++ b/packages/web/netlify.toml
@@ -1,0 +1,5 @@
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+  [plugins.inputs.settings]
+    preset = "desktop" # Run Lighthouse using a desktop configuration since we target only desktop


### PR DESCRIPTION
The Lighthouse integration in Netlify defaults to mobile apps. We are adding config to use Desktop https://github.com/netlify/netlify-plugin-lighthouse?tab=readme-ov-file#run-lighthouse-audits-for-desktop